### PR TITLE
adding uber jar build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ target
 └─── msk-config-providers-<VERSION>.jar
 ```
 
+Additionally, there is a flat UBER jar at the following location:
+
+```
+target
+├── shade-uber
+│   └── msk-config-providers-<VERSION>-uber.jar
+└── .......
+```
+
+
 ## Access Management
 
 Currently config providers do not support credentials to be explicitly provided. Config provider will inherit any type of credentials of hosting application, OS or service.

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,54 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.2.4</version>
+				<configuration>
+					<createDependencyReducedPom>false</createDependencyReducedPom>
+					<filters>
+						<filter>
+							<artifact>*:*</artifact>
+							<excludes>
+								<exclude>module-info.class</exclude>
+							</excludes>
+						</filter>
+					</filters>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.build.directory}/shade-uber</outputDirectory>
+							<finalName>${project.artifactId}-${project.version}-uber</finalName>
+							<artifactSet>
+								<excludes>
+									<exclude>org.apache.kafka:*</exclude>
+									<exclude>slf4j-api:*</exclude>
+									<exclude>com.fasterxml.jackson.annotation:*</exclude>
+									<exclude>com.fasterxml.jackson.core:*</exclude>
+									<exclude>com.fasterxml.jackson.dataformat:*</exclude>
+									<exclude>com.fasterxml.jackson.dataformat:*</exclude>
+									<exclude>jackson*:jackson-databind:jar:</exclude>
+								</excludes>
+							</artifactSet>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.0</version>
+				<configuration>
+					<release>11</release>
+				</configuration>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
*Issue #, if available:*
Issue #4

*Description of changes:*
Adds new build artifact - Uber jar under `target/shade-uber` dir

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
