### PR TITLE
feature: Workaround to allow passing an ARN for a Secret in addition to the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ config.providers.s3import.class          = com.amazonaws.kafka.config.providers.
 config.providers.secretsmanager.param.region   = us-west-2
 config.providers.s3import.param.region         = us-west-2
 
-# optional configuration if you need to access a Secret via an ARN (for example if in a different account)
-config.providers.secretsmanager.param.separator.replacement = |
-
 # below is an example of config provider usage to supply a truststore location and its password. 
 # Actual parameter names depend on how those config providers are used in the client's configuration.
 database.ssl.truststore.password         = ${secretsmanager:mySslCertCredentials:ssl_trust_pass}
 database.ssl.truststore.location         = ${s3import:us-west-2:my_cert_bucket/pass/to/trustore_unique_filename.jks}
 
-# Example of accessing a Secret via an ARN
-database.password = ${secretsmanager:arn|aws|secretsmanager|us-west-2|123477892456|secret|/db/admin_user_credentials-ieAE11:password}
+# Example of accessing a Secret via an ARN which has been URL Encoded
+database.password = ${secretsmanager:arn%3Aaws%3Asecretsmanager%3Aus-west-2%3A123477892456%3Asecret%3A%2Fdb%2Fadmin_user_credentials-ieAE11:password}
 ```
+
+> NOTE: For the `secretsmanager` provider, the base parser from Kafka does not support using ARNs due to the `:` character. 
+> In this case, URL encode the ARN first, and it will be decoded correctly by this Provider. 
 
 More information about configuration of the config providers and usage, see below per config provider.
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ config.providers.s3import.class          = com.amazonaws.kafka.config.providers.
 config.providers.secretsmanager.param.region   = us-west-2
 config.providers.s3import.param.region         = us-west-2
 
+# optional configuration if you need to access a Secret via an ARN (for example if in a different account)
+config.providers.secretsmanager.param.separator.replacement = |
+
 # below is an example of config provider usage to supply a truststore location and its password. 
 # Actual parameter names depend on how those config providers are used in the client's configuration.
 database.ssl.truststore.password         = ${secretsmanager:mySslCertCredentials:ssl_trust_pass}
 database.ssl.truststore.location         = ${s3import:us-west-2:my_cert_bucket/pass/to/trustore_unique_filename.jks}
+
+# Example of accessing a Secret via an ARN
+database.password = ${secretsmanager:arn|aws|secretsmanager|us-west-2|123477892456|secret|/db/admin_user_credentials-ieAE11:password}
 ```
 
 More information about configuration of the config providers and usage, see below per config provider.

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>software.amazon.msk</groupId>
 	<artifactId>msk-config-providers</artifactId>
-	<version>0.3.0-SNAPSHOT</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<name>msk-config-providers</name>
 	<description>custom config plugins for Kafka Connect</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>software.amazon.msk</groupId>
 	<artifactId>msk-config-providers</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.3.0-SNAPSHOT</version>
 	<name>msk-config-providers</name>
 	<description>custom config plugins for Kafka Connect</description>
 

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
  * software and associated documentation files (the "Software"), to deal in the Software
  * without restriction, including without limitation the rights to use, copy, modify,
  * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
  * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
@@ -40,10 +40,10 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
 
 /**
  * This class implements a ConfigProvider for AWS Secrets Manager.<br>
- * 
+ *
  * <p><b>Usage:</b><br>
  * In a configuration file (e.g. {@code client.properties}) define following properties:<br>
- * 
+ *
  * <pre>
  * #        Step1. Configure the secrets manager as config provider:
  * config.providers=secretsmanager
@@ -52,49 +52,49 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
  * config.providers.secretsmanager.param.region=us-west-2
  * # optional parameter, see more details below
  * config.providers.secretsmanager.param.NotFoundStrategy=fail
- * 
+ *
  * #        Step 2. Usage of AWS secrets manager as config provider:
  * db.username=${secretsmanager:AmazonMSK_TestKafkaConfig:username}
  * db.password=${secretsmanager:AmazonMSK_TestKafkaConfig:password}
  * </pre>
- * 
+ *
  * Note, this config provider implementation assumes secret values will be returned in Json format.
  * Nested values aren't supported at this point.<br>
- * 
+ *
  * SecretsManagerConfigProvider can be configured using parameters.<br>
  * Format:<br>
  * {@code config.providers.secretsmanager.param.<param_name> = <param_value>}<br>
- * 
+ *
  * @param region - defines a region to get a secret from.
  * @param NotFoundStrategy - defines an action in case requested secret or a key in a value cannot be resolved. <br>
  * <ul>Passible values are:
  * 	<ul>{@code fail} - (Default) the code will throw an exception {@code ConfigNotFoundException}</ul>
  * 	<ul>{@code ignore} - a value will remain with tokens without any change </ul>
  * </ul>
- * 
- * 
+ *
+ *
  * Expression usage:<br>
  * <code>property_name=${secretsmanager:secret.id:secret.key}</code>
  *
  */
 public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
-    
+
     private final Logger log = LoggerFactory.getLogger(getClass());
-    
+
     private static final String EMPTY = "";
 
     private SecretsManagerConfig config;
     private String notFoundStrategy;
 
     private SecretsManagerClientBuilder cBuilder;
-    
+
     @Override
 	public void configure(Map<String, ?> configs) {
 	    this.config = new SecretsManagerConfig(configs);
         setCommonConfig(config);
 
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
-        
+
         // set up a builder:
         this.cBuilder = SecretsManagerClient.builder();
         setClientCommonConfig(this.cBuilder);
@@ -111,31 +111,30 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         return get(path, Collections.emptySet());
     }
 
-    
+
     /**
      * Retrieves secret's fields from a given secret.
      *
-     * @param path AWS Secrets Manager <code> secret </code>
+     * @param providedPath AWS Secrets Manager <code> secret name or encoded ARN </code>
      * @param keys fields inside a given secret.
      * @return the configuration data
      */
     @Override
-	public ConfigData get(String path, Set<String> keys) {
+	public ConfigData get(String providedPath, Set<String> keys) {
         Map<String, String> data = new HashMap<>();
-		if (   path == null || path.isEmpty() 
+		if (providedPath == null || providedPath.isEmpty()
 			|| keys== null || keys.isEmpty()   ) {
 		    // if no fields provided, just ignore this usage
 			return new ConfigData(data);
 		}
-
+		String path = unmaskPath(providedPath);
 		GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
 		Map<String, String> secretJson = null;
 		try {
 			SecretsManagerClient secretsClient = checkOrInitSecretManagerClient();
-            GetSecretValueResponse response = secretsClient .getSecretValue(request);
+            GetSecretValueResponse response = secretsClient.getSecretValue(request);
 			String value = response.secretString();
-			
-	        
+
 	        try {
 	            secretJson = new ObjectMapper().readValue(value, new TypeReference<>() {});
 	        } catch (Exception e) {
@@ -146,13 +145,13 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
             log.info("Secret id {} not found. Value will be handled according to a strategy defined by 'NotFoundStrategy'", path);
             handleNotFoundByStrategy(data, path, null, e);
         }
-		
+
         Long ttl = null;
         for (String keyWithOptions: keys) {
             String key = parseKey(keyWithOptions);
             Map<String, String> options = parseKeyOptions(keyWithOptions);
             ttl = getUpdatedTtl(ttl, options);
-            
+
 		    // secretJson can be null at this point only if there is a permissive strategy.
 		    if (secretJson == null) {
 		        data.put(key, EMPTY);
@@ -172,7 +171,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     protected SecretsManagerClient checkOrInitSecretManagerClient() {
         return cBuilder.build();
     }
-	
+
 	@Override
 	public void subscribe(String path, Set<String> keys, ConfigChangeCallback callback) {
 	    log.info("Subscription is not implemented and will be ignored");
@@ -181,9 +180,9 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
 	@Override
 	public void close() throws IOException {
 	}
-	
+
 	private void handleNotFoundByStrategy(Map<String, String> data, String path, String key, RuntimeException e) {
-		if (SecretsManagerConfig.NOT_FOUND_IGNORE.equals(this.notFoundStrategy) 
+		if (SecretsManagerConfig.NOT_FOUND_IGNORE.equals(this.notFoundStrategy)
 		        && key != null && !key.isBlank()) {
 		    data.put(key, "");
 		} else if (SecretsManagerConfig.NOT_FOUND_FAIL.equals(this.notFoundStrategy)) {

--- a/src/main/java/com/amazonaws/kafka/config/providers/common/AwsServiceConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/common/AwsServiceConfigProvider.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this
  * software and associated documentation files (the "Software"), to deal in the Software
  * without restriction, including without limitation the rights to use, copy, modify,
  * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
  * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
  * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
@@ -35,12 +35,11 @@ import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
 import software.amazon.awssdk.regions.Region;
 
 public abstract class AwsServiceConfigProvider implements ConfigProvider {
-
+    
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private String region;
     private String endpoint;
-    private String separatorReplacement;
 
 
     public String getRegion() {
@@ -59,14 +58,6 @@ public abstract class AwsServiceConfigProvider implements ConfigProvider {
         this.endpoint = endpoint;
     }
 
-    public String getSeparatorReplacement() {
-        return separatorReplacement;
-    }
-
-    public void setSeparatorReplacement(String separatorReplacement) {
-        this.separatorReplacement = separatorReplacement;
-    }
-
     /**
      * Set common AWS configuration parameters, like region, endpoint, etc...
      * @param config
@@ -76,7 +67,6 @@ public abstract class AwsServiceConfigProvider implements ConfigProvider {
         // default region from configuration. It can be null, empty or blank.
         this.region = config.getString(CommonConfigUtils.REGION);
         this.endpoint = config.getString(CommonConfigUtils.ENDPOINT);
-        this.separatorReplacement = config.getString(CommonConfigUtils.SEPARATOR_REPLACEMENT);
     }
 
     @Override
@@ -87,7 +77,7 @@ public abstract class AwsServiceConfigProvider implements ConfigProvider {
 
     public void close() throws IOException {
     }
-
+    
     /**
      * Set configuration that is common to most AWS Clients.
      * @param <T>
@@ -95,11 +85,11 @@ public abstract class AwsServiceConfigProvider implements ConfigProvider {
      * @return
      */
     protected <T extends AwsClientBuilder<?,?>> T setClientCommonConfig(T cBuilder) {
-
+        
         if (this.region != null && !this.region.isBlank()) {
             cBuilder.region(Region.of(this.region));
         }
-
+        
         if (this.endpoint != null && !endpoint.isBlank())
             try {
                 cBuilder.endpointOverride(new URI(this.endpoint));
@@ -107,57 +97,48 @@ public abstract class AwsServiceConfigProvider implements ConfigProvider {
                 log.error("Invalid syntax, ", e);
                 throw new RuntimeException(e);
             }
-
+            
         return cBuilder;
     }
-
+    
 
     protected String parseKey(String keyWithOptions) {
         if (keyWithOptions == null) return keyWithOptions;
-
+        
         return keyWithOptions.split("\\?", 2)[0];
     }
-
+    
     protected Map<String, String> parseKeyOptions(String keyWithOptions) {
-
+        
         Map<String, String> options = new LinkedHashMap<>();
-
+        
         if (keyWithOptions == null) return options;
 
         String[] parsed = keyWithOptions.split("\\?", 2);
         if (parsed.length < 2) return options;
-
+        
         Matcher m = Pattern.compile("(\\w+)=(.*?)(?=,\\w+=|$)").matcher(parsed[1]);
         while (m.find()) {
             options.put(m.group(1), m.group(2));
         }
-
+        
         return options;
     }
-
+    
     protected Long getUpdatedTtl(Long currentTtl, Map<String, String> options) {
         if (options == null || options.isEmpty()) return currentTtl;
 
         String newTtlStr = options.get("ttl");
         if (newTtlStr == null) return currentTtl;
-
+        
         try {
             Long newTtl = Long.valueOf(newTtlStr);
-            return currentTtl == null || currentTtl > newTtl
-                    ? newTtl
+            return currentTtl == null || currentTtl > newTtl 
+                    ? newTtl 
                     : currentTtl;
         }catch(Exception e) {
             log.warn("TTL value '{}' is not a number", newTtlStr, e);
         }
         return currentTtl;
-    }
-
-    /**
-     * Unmask any ':' characters that were replaced in the original path via the Seperator Replacement value.
-     * @param providedPath path value parsed from `secretsmanager:` reference
-     * @return path with any ':' characters replaced back
-     */
-    protected String unmaskPath(String providedPath) {
-        return this.separatorReplacement != null && !this.separatorReplacement.isBlank() ? providedPath.replace(this.separatorReplacement, ":") : providedPath;
     }
 }

--- a/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
@@ -37,10 +37,6 @@ public class CommonConfigUtils {
             + "If there is an endpoint for a service in a VPC, and it should be used instead of default one, "
             + "this is the way to explicitly provide one.";
 
-    public static final String SEPARATOR_REPLACEMENT = "separator.replacement";
-    private static final String SEPARATOR_REPLACEMENT_DOC = "(Optional) If the 'path' value of a Secret reference contains a ':' (for example if it is an ARN), "
-            + "this will fail parsing. This parameter allows specifying a replacement for the ':' character in the path being passed in, "
-            + "which will be changed back to ':' before being used to fetch the Secret value";
 
     /**
      * 
@@ -61,13 +57,6 @@ public class CommonConfigUtils {
                         "",
                         ConfigDef.Importance.MEDIUM,
                         ENDPOINT_DOC
-                        )
-                .define(
-                        SEPARATOR_REPLACEMENT,
-                        ConfigDef.Type.STRING,
-                        "",
-                        ConfigDef.Importance.MEDIUM,
-                        SEPARATOR_REPLACEMENT_DOC
                         )
                 ;
     }

--- a/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/common/CommonConfigUtils.java
@@ -37,6 +37,10 @@ public class CommonConfigUtils {
             + "If there is an endpoint for a service in a VPC, and it should be used instead of default one, "
             + "this is the way to explicitly provide one.";
 
+    public static final String SEPARATOR_REPLACEMENT = "separator.replacement";
+    private static final String SEPARATOR_REPLACEMENT_DOC = "(Optional) If the 'path' value of a Secret reference contains a ':' (for example if it is an ARN), "
+            + "this will fail parsing. This parameter allows specifying a replacement for the ':' character in the path being passed in, "
+            + "which will be changed back to ':' before being used to fetch the Secret value";
 
     /**
      * 
@@ -57,6 +61,13 @@ public class CommonConfigUtils {
                         "",
                         ConfigDef.Importance.MEDIUM,
                         ENDPOINT_DOC
+                        )
+                .define(
+                        SEPARATOR_REPLACEMENT,
+                        ConfigDef.Type.STRING,
+                        "",
+                        ConfigDef.Importance.MEDIUM,
+                        SEPARATOR_REPLACEMENT_DOC
                         )
                 ;
     }

--- a/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
@@ -17,8 +17,11 @@ public class MockedSecretsManagerConfigProvider extends SecretsManagerConfigProv
         when(secretsClient.getSecretValue(request("AmazonMSK_TestKafkaConfig"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
         );
-        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_secret"))).thenAnswer(
+        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John2\", \"password\":\"Password567\"}")
+        );
+        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John3\", \"password\":\"Password321\"}")
         );
         when(secretsClient.getSecretValue(request("AmazonMSK_TestTTL"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")

--- a/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
@@ -17,6 +17,9 @@ public class MockedSecretsManagerConfigProvider extends SecretsManagerConfigProv
         when(secretsClient.getSecretValue(request("AmazonMSK_TestKafkaConfig"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
         );
+        when(secretsClient.getSecretValue(request("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_secret"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John2\", \"password\":\"Password567\"}")
+        );
         when(secretsClient.getSecretValue(request("AmazonMSK_TestTTL"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
         );

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -42,6 +42,7 @@ public class SecretsManagerConfigProviderTest {
 		props.put("config.providers.secretsmanager.class", "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
 		props.put("config.providers.secretsmanager.param.region", "us-west-2");
 		props.put("config.providers.secretsmanager.param.NotFoundStrategy", "fail");
+		props.put("config.providers.secretsmanager.param.separator.replacement", "|");
 	}
     
     @Test
@@ -53,6 +54,17 @@ public class SecretsManagerConfigProviderTest {
     	
     	assertEquals("John", testConfig.getString("username"));
     	assertEquals("Password123", testConfig.getString("password"));
+    }
+
+    @Test
+    public void testExistingKeysViaArn() {
+		props.put("username", "${secretsmanager:arn|aws|secretsmanager|ap-southeast-2|123456789|secret|AmazonMSK_my_secret:username}");
+		props.put("password", "${secretsmanager:arn|aws|secretsmanager|ap-southeast-2|123456789|secret|AmazonMSK_my_secret:password}");
+
+    	CustomConfig testConfig = new CustomConfig(props);
+
+    	assertEquals("John2", testConfig.getString("username"));
+    	assertEquals("Password567", testConfig.getString("password"));
     }
 
     @Test

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -37,61 +37,61 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
 
 public class SecretsManagerConfigProviderTest {
 
-	Map<String, Object> props;
+    Map<String, Object> props;
     @BeforeEach
     public void setup() {
-		props = new HashMap<>();
-		props.put("config.providers", "secretsmanager");
-		props.put("config.providers.secretsmanager.class", "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
-		props.put("config.providers.secretsmanager.param.region", "us-west-2");
-		props.put("config.providers.secretsmanager.param.NotFoundStrategy", "fail");
-	}
+        props = new HashMap<>();
+        props.put("config.providers", "secretsmanager");
+        props.put("config.providers.secretsmanager.class", "com.amazonaws.kafka.config.providers.MockedSecretsManagerConfigProvider");
+        props.put("config.providers.secretsmanager.param.region", "us-west-2");
+        props.put("config.providers.secretsmanager.param.NotFoundStrategy", "fail");
+    }
     
     @Test
     public void testExistingKeys() {
-		props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username}");
-		props.put("password", "${secretsmanager:AmazonMSK_TestKafkaConfig:password}");
-		
-    	CustomConfig testConfig = new CustomConfig(props);
-    	
-    	assertEquals("John", testConfig.getString("username"));
-    	assertEquals("Password123", testConfig.getString("password"));
+        props.put("username", "${secretsmanager:AmazonMSK_TestKafkaConfig:username}");
+        props.put("password", "${secretsmanager:AmazonMSK_TestKafkaConfig:password}");
+
+        CustomConfig testConfig = new CustomConfig(props);
+
+        assertEquals("John", testConfig.getString("username"));
+        assertEquals("Password123", testConfig.getString("password"));
     }
 
     @Test
     public void testExistingKeysViaArn() {
         String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret", StandardCharsets.UTF_8);
         props.put("username", "${secretsmanager:" + arn + ":username}");
-		props.put("password", "${secretsmanager:" + arn + ":password}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
 
-    	CustomConfig testConfig = new CustomConfig(props);
+        CustomConfig testConfig = new CustomConfig(props);
 
-    	assertEquals("John2", testConfig.getString("username"));
-    	assertEquals("Password567", testConfig.getString("password"));
+        assertEquals("John2", testConfig.getString("username"));
+        assertEquals("Password567", testConfig.getString("password"));
     }
 
     @Test
     public void testExistingKeysViaArnWithEncodedValue() {
         String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret%3A", StandardCharsets.UTF_8);
-		props.put("username", "${secretsmanager:" + arn + ":username}");
-		props.put("password", "${secretsmanager:" + arn + ":password}");
+        props.put("username", "${secretsmanager:" + arn + ":username}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
 
-    	CustomConfig testConfig = new CustomConfig(props);
+        CustomConfig testConfig = new CustomConfig(props);
 
-    	assertEquals("John3", testConfig.getString("username"));
-    	assertEquals("Password321", testConfig.getString("password"));
+        assertEquals("John3", testConfig.getString("username"));
+        assertEquals("Password321", testConfig.getString("password"));
     }
 
     @Test
     public void testExistingKeysViaHandEncodedArn() {
         String arn = "arn%3Aaws%3Asecretsmanager%3Aap-southeast-2%3A123456789%3Asecret%3AAmazonMSK_my_service%2Fmy_secret";
-		props.put("username", "${secretsmanager:" + arn + ":username}");
-		props.put("password", "${secretsmanager:" + arn + ":password}");
+        props.put("username", "${secretsmanager:" + arn + ":username}");
+        props.put("password", "${secretsmanager:" + arn + ":password}");
 
-    	CustomConfig testConfig = new CustomConfig(props);
+        CustomConfig testConfig = new CustomConfig(props);
 
-    	assertEquals("John2", testConfig.getString("username"));
-    	assertEquals("Password567", testConfig.getString("password"));
+        assertEquals("John2", testConfig.getString("username"));
+        assertEquals("Password567", testConfig.getString("password"));
     }
 
     @Test
@@ -118,14 +118,14 @@ public class SecretsManagerConfigProviderTest {
     }
     
     static class CustomConfig extends AbstractConfig {
-    	final static String DEFAULT_DOC = "Default Doc";
-    	final static ConfigDef CONFIG = new ConfigDef()
-    			.define("username", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
-    			.define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
-    			;
-		public CustomConfig(Map<?, ?> originals) {
-			super(CONFIG, originals);
-		}
+        final static String DEFAULT_DOC = "Default Doc";
+        final static ConfigDef CONFIG = new ConfigDef()
+                .define("username", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
+                .define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
+                ;
+        public CustomConfig(Map<?, ?> originals) {
+            super(CONFIG, originals);
+        }
     }
-	
+
 }


### PR DESCRIPTION
ARNs contain a ':' characters, which the upstream parsing logic in Kafka already treats as a separator and will not handle correctly.

This allows you to mask these characters with an alternative (say '|'), which is safely passed through and then converted back before retrieving the Secret.

A new configuration param is exposed (`separator.replacement`) to allow you to specify the replacement character. This will simply be search and replaced later (if the replacement character does not exist in the string, no changes will be made or error thrown).

Fixes aws-samples/msk-config-providers#22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
