### PR TITLE
fix: Downgrading software.amazon.awssdk.version to be able to run secrets …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>software.amazon.msk</groupId>
 	<artifactId>msk-config-providers</artifactId>
-	<version>0.3.1</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<name>msk-config-providers</name>
 	<description>custom config plugins for Kafka Connect</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>software.amazon.msk</groupId>
 	<artifactId>msk-config-providers</artifactId>
-	<version>0.4.0-SNAPSHOT</version>
+	<version>0.3.1</version>
 	<name>msk-config-providers</name>
 	<description>custom config plugins for Kafka Connect</description>
 
@@ -12,7 +12,7 @@
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
 		<junit.jupiter.version>5.9.1</junit.jupiter.version>
 		<slf4j.version>1.7.32</slf4j.version>
-		<software.amazon.awssdk.version>2.29.11</software.amazon.awssdk.version>
+		<software.amazon.awssdk.version>2.18.8</software.amazon.awssdk.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>software.amazon.msk</groupId>
 	<artifactId>msk-config-providers</artifactId>
-	<version>0.3.0</version>
+	<version>0.4.0-SNAPSHOT</version>
 	<name>msk-config-providers</name>
 	<description>custom config plugins for Kafka Connect</description>
 


### PR DESCRIPTION
Fixes #28 

*Description of changes:*
Downgrading software.amazon.awssdk.version to the one it was used on r.0.2.0 (`2.18.8`) to  be able to run secrets manager provider in msk connect


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
