### PR TITLE
ISSUE-26-NPE - recreate client builder

### DIFF
--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -89,6 +89,8 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     private String notFoundStrategy;
 
     private SecretsManagerClientBuilder cBuilder;
+    private long timeLastBuilt;
+    private static final long BUILDER_TTL_MS = 1*60*1000; // 1 min TTL
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -96,8 +98,12 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         setCommonConfig(config);
 
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
-
+        initClientBuilder();
+    }
+    
+    private void initClientBuilder() {
         // set up a builder:
+        this.timeLastBuilt = System.currentTimeMillis();
         this.cBuilder = SecretsManagerClient.builder();
         setClientCommonConfig(this.cBuilder);
     }
@@ -171,7 +177,10 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
     }
 
-    protected SecretsManagerClient checkOrInitSecretManagerClient() {
+    protected synchronized SecretsManagerClient checkOrInitSecretManagerClient() {
+        if (System.currentTimeMillis() > this.timeLastBuilt + BUILDER_TTL_MS) {
+            initClientBuilder();
+        }
         return cBuilder.build();
     }
 


### PR DESCRIPTION
*Issue #26*
NullPointerException instantiating SecretsManagerConfigProvider

*Description of changes:*
A client's builder maintain context in the internal attributes. This change introduces an ability to re-create a builder.
Time-to-live attribute has been added and used to avoid re-creation of the builder at client start-up. Current TTL is set to 1 minute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
