### PR TITLE
fix: prevent secretsManagerclientBuilder usage across threads

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>2.7.2</version>
+			<version>3.7.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -88,7 +88,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     private SecretsManagerConfig config;
     private String notFoundStrategy;
 
-    private SecretsManagerClientBuilder cBuilder;
+    private SecretsManagerClient secretsManager;
 
     @Override
     public void configure(Map<String, ?> configs) {
@@ -98,8 +98,9 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
 
         // set up a builder:
-        this.cBuilder = SecretsManagerClient.builder();
-        setClientCommonConfig(this.cBuilder);
+        SecretsManagerClientBuilder cBuilder = SecretsManagerClient.builder();
+        setClientCommonConfig(cBuilder);
+        this.secretsManager = cBuilder.build();
     }
 
     /**
@@ -172,7 +173,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     }
 
     protected SecretsManagerClient checkOrInitSecretManagerClient() {
-        return cBuilder.build();
+        return this.secretsManager;
     }
 
     @Override
@@ -182,6 +183,12 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
 
     @Override
     public void close() throws IOException {
+        log.info("Closing provider, called by thread: {}",
+                Thread.currentThread().getName());
+        if (this.secretsManager != null) {
+            this.secretsManager.close();
+        }
+        super.close();
     }
 
     private void handleNotFoundByStrategy(Map<String, String> data, String path, String key, RuntimeException e) {

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -93,10 +93,10 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     @Override
     public void configure(Map<String, ?> configs) {
         this.config = new SecretsManagerConfig(configs);
-        configure(this.config);
+        configure();
     }
 
-    public void configure(SecretsManagerConfig configs) {
+    public void configure() {
         setCommonConfig(config);
 
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
@@ -178,7 +178,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
 
     protected synchronized SecretsManagerClient checkOrInitSecretManagerClient() {
         if (secretsManager == null) {
-            configure(config);
+            configure();
         }
         return this.secretsManager;
     }

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -70,8 +70,8 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
  * @param region - defines a region to get a secret from.
  * @param NotFoundStrategy - defines an action in case requested secret or a key in a value cannot be resolved. <br>
  * <ul>Passible values are:
- * 	<ul>{@code fail} - (Default) the code will throw an exception {@code ConfigNotFoundException}</ul>
- * 	<ul>{@code ignore} - a value will remain with tokens without any change </ul>
+ *  <ul>{@code fail} - (Default) the code will throw an exception {@code ConfigNotFoundException}</ul>
+ *  <ul>{@code ignore} - a value will remain with tokens without any change </ul>
  * </ul>
  *
  *
@@ -93,6 +93,10 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     @Override
     public void configure(Map<String, ?> configs) {
         this.config = new SecretsManagerConfig(configs);
+        configure(this.config);
+    }
+
+    public void configure(SecretsManagerConfig configs) {
         setCommonConfig(config);
 
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
@@ -172,7 +176,10 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
     }
 
-    protected SecretsManagerClient checkOrInitSecretManagerClient() {
+    protected synchronized SecretsManagerClient checkOrInitSecretManagerClient() {
+        if (secretsManager == null) {
+            configure(config);
+        }
         return this.secretsManager;
     }
 
@@ -187,6 +194,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
                 Thread.currentThread().getName());
         if (this.secretsManager != null) {
             this.secretsManager.close();
+            this.secretsManager = null;
         }
         super.close();
     }

--- a/src/main/java/com/amazonaws/kafka/config/providers/SsmParamStoreConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SsmParamStoreConfigProvider.java
@@ -29,6 +29,8 @@ import org.slf4j.LoggerFactory;
 
 import com.amazonaws.kafka.config.providers.common.AwsServiceConfigProvider;
 
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;
@@ -81,19 +83,24 @@ public class SsmParamStoreConfigProvider extends AwsServiceConfigProvider {
 	private String notFoundStrategy;
 
 	private SsmParamStoreConfig config;
-    private SsmClientBuilder cBuilder;
+    private SsmClient ssmClient;
 
     @Override
 	public void configure(Map<String, ?> configs) {
         this.config = new SsmParamStoreConfig(configs);
-        setCommonConfig(config);
-
-        this.notFoundStrategy = config.getString(SsmParamStoreConfig.NOT_FOUND_STRATEGY);
-        
-        // set up a builder:
-        this.cBuilder = SsmClient.builder();
-        setClientCommonConfig(this.cBuilder);
+        configure();
 	}
+
+    private void configure() {
+        setCommonConfig(this.config);
+
+        this.notFoundStrategy = this.config.getString(SsmParamStoreConfig.NOT_FOUND_STRATEGY);
+
+        // set up a builder:
+        SsmClientBuilder cBuilder = SsmClient.builder();
+        setClientCommonConfig(cBuilder);
+        this.ssmClient = cBuilder.build();
+    }
 
     /**
      * Retrieves all parameters at the given path in SSM Parameters Store.
@@ -143,12 +150,22 @@ public class SsmParamStoreConfigProvider extends AwsServiceConfigProvider {
 		return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
 	}
 
-    protected SsmClient checkOrInitSsmClient() {
-        return cBuilder.build();
+    protected synchronized SsmClient checkOrInitSsmClient() {
+        if (this.ssmClient == null) {
+            configure();
+        }
+        return this.ssmClient;
     }
 	
 	@Override
 	public void close() throws IOException {
+        log.info("Closing provider, called by thread: {}",
+                Thread.currentThread().getName());
+        if (this.ssmClient != null) {
+            this.ssmClient.close();
+            this.ssmClient = null;
+        }
+        super.close();
 	}
 	
     private void handleNotFoundByStrategy(Map<String, String> data, String path, String key, RuntimeException e) {

--- a/src/main/java/com/amazonaws/kafka/config/providers/SsmParamStoreConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SsmParamStoreConfigProvider.java
@@ -29,8 +29,6 @@ import org.slf4j.LoggerFactory;
 
 import com.amazonaws.kafka.config.providers.common.AwsServiceConfigProvider;
 
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
-import software.amazon.awssdk.services.secretsmanager.SecretsManagerClientBuilder;
 import software.amazon.awssdk.services.ssm.SsmClient;
 import software.amazon.awssdk.services.ssm.SsmClientBuilder;
 import software.amazon.awssdk.services.ssm.model.GetParameterRequest;


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/aws-samples/msk-config-providers/issues/32

*Description of changes:*
Submitting a bug fix to prevent nullPointerException when SecretsManagerClientBuilder is used across multiple threads in Kafka Connect distributed mode. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.