### PR TITLE
fix: bump AWS SDK from 2.41.1 to 2.44.12 to resolve Netty CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
 		<junit.jupiter.version>5.9.1</junit.jupiter.version>
 		<slf4j.version>1.7.32</slf4j.version>
-		<software.amazon.awssdk.version>2.41.1</software.amazon.awssdk.version>
+		<software.amazon.awssdk.version>2.44.12</software.amazon.awssdk.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Upgrades software.amazon.awssdk from 2.41.1 to 2.44.12, which pulls Netty 4.1.133.Final (up from 4.1.114.Final). This resolves:
- CVE-2026-42581
- CVE-2026-33870

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
