### PR TITLE
Support raw secret retrieval with wildcard key selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,35 @@ Note,
 - TTL value is in milliseconds
 - upon an expiration, the entire connector will be restarted, regardless whether a value has been changed or not.
 
+** Raw Secret Retrieval **
+
+The `secretsmanager` provider supports retrieving the entire secret value as a raw string by omitting the key from the reference (two-segment form). This is useful when the secret contains nested JSON or other structures that cannot be represented as flat key-value pairs.
+
+```
+# Retrieve the entire secret value as a raw string:
+my.config = ${secretsmanager:mySecretName}
+
+# Also works with URL-encoded ARNs:
+my.config = ${secretsmanager:arn%3Aaws%3Asecretsmanager%3Aus-west-2%3A123456789%3Asecret%3AmySecret}
+
+# TTL is supported with the two-segment form:
+my.config = ${secretsmanager:mySecretName?ttl=300000}
+```
+
+By default the raw secret string is returned as-is. If the secret value contains characters that require escaping in your configuration context (e.g., double quotes in JAAS configs), you can configure the provider to return a Base64-encoded string instead:
+
+```
+# Configure Base64 encoding for raw secret retrieval:
+config.providers.secretsmanager.param.RawSecretEncoding = base64
+
+# The resolved value will be a Base64-encoded string that your application decodes at runtime:
+my.config = ${secretsmanager:mySecretName}
+```
+
+Supported values for `RawSecretEncoding`:
+- `none` (default) — returns the raw secret string as-is
+- `base64` — returns the secret string Base64-encoded
+
 
 ## Build
 

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfig.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfig.java
@@ -29,13 +29,25 @@ public class SecretsManagerConfig extends AbstractConfig{
     public static final String NOT_FOUND_STRATEGY = "NotFoundStrategy";
     public static final String NOT_FOUND_FAIL = "fail";
     public static final String NOT_FOUND_IGNORE = "ignore";
-    
-    private static final String NOT_FOUND_STRATEGY_DOC = 
+
+    public static final String RAW_SECRET_ENCODING = "RawSecretEncoding";
+    public static final String RAW_SECRET_ENCODING_NONE = "none";
+    public static final String RAW_SECRET_ENCODING_BASE64 = "base64";
+
+    private static final String NOT_FOUND_STRATEGY_DOC =
             "An action to take in case a secret cannot be found. "
             + "Possible actions are: `ignore` and `fail`. <br>"
             + "If `ignore` is selected and a secret cannot be found, the empty string will be assigned to a parameter.<br>"
             + "If `fail` is selected, the config provider will throw an exception to signal the issue.<br>"
             + "If there is a connectivity or access issue with AWS Secrets Manager service, an exception will be thrown.";
+
+    private static final String RAW_SECRET_ENCODING_DOC =
+            "Encoding to apply when returning the entire secret value via the two-segment form (e.g., ${secretsmanager:mySecret}). "
+            + "Possible values are: `none` and `base64`. <br>"
+            + "If `none` is selected, the raw secret string is returned as-is. "
+            + "Note: if the secret value contains double quotes (e.g., JSON), these must be escaped for use in JAAS configs.<br>"
+            + "If `base64` is selected, the secret string is Base64-encoded before being returned, "
+            + "which avoids special character escaping requirements.";
 
     public SecretsManagerConfig(Map<?, ?> originals) {
         super(config(), originals);
@@ -50,7 +62,14 @@ public class SecretsManagerConfig extends AbstractConfig{
                         ValidString.in(NOT_FOUND_FAIL, NOT_FOUND_IGNORE),
                         ConfigDef.Importance.LOW,
                         NOT_FOUND_STRATEGY_DOC
-                        )
-                ;
+                )
+                .define(
+                        RAW_SECRET_ENCODING,
+                        ConfigDef.Type.STRING,
+                        RAW_SECRET_ENCODING_NONE,
+                        ValidString.in(RAW_SECRET_ENCODING_NONE, RAW_SECRET_ENCODING_BASE64),
+                        ConfigDef.Importance.LOW,
+                        RAW_SECRET_ENCODING_DOC
+                );
     }
 }

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -138,8 +138,11 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
 
         String path = URLDecoder.decode(encodedPath, StandardCharsets.UTF_8);
 
-        if (keys.size() == 1 && keys.contains(RAW_SECRET_KEY)) {
-            return getRawSecret(path);
+        if (keys.size() == 1 && parseKey(keys.iterator().next()).equals(RAW_SECRET_KEY)) {
+            String keyWithOptions = keys.iterator().next();
+            Map<String, String> options = parseKeyOptions(keyWithOptions);
+            Long ttl = getUpdatedTtl(null, options);
+            return getRawSecret(path, keyWithOptions, ttl);
         }
 
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
@@ -187,18 +190,18 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
      * Used when the key selector is '*' (e.g., ${secretsmanager:mySecret:*}).
      * Returns the entire secret value as-is, allowing the consumer to parse it directly.
      */
-    private ConfigData getRawSecret(String path) {
+    private ConfigData getRawSecret(String path, String keyWithOptions, Long ttl) {
         Map<String, String> data = new HashMap<>();
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
         try {
             SecretsManagerClient secretsClient = checkOrInitSecretManagerClient();
             GetSecretValueResponse response = secretsClient.getSecretValue(request);
-            data.put(RAW_SECRET_KEY, response.secretString());
+            data.put(keyWithOptions, response.secretString());
         } catch (ResourceNotFoundException e) {
             log.info("Secret id {} not found. Value will be handled according to a strategy defined by 'NotFoundStrategy'", path);
             handleNotFoundByStrategy(data, path, null, e);
         }
-        return new ConfigData(data);
+        return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
     }
 
     protected synchronized SecretsManagerClient checkOrInitSecretManagerClient() {

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -84,6 +84,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String EMPTY = "";
+    private static final String RAW_SECRET_KEY = "*";
 
     private SecretsManagerConfig config;
     private String notFoundStrategy;
@@ -136,6 +137,11 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         }
 
         String path = URLDecoder.decode(encodedPath, StandardCharsets.UTF_8);
+
+        if (keys.size() == 1 && keys.contains(RAW_SECRET_KEY)) {
+            return getRawSecret(path);
+        }
+
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
         Map<String, String> secretJson = null;
         try {
@@ -174,6 +180,25 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         }
 
         return ttl == null ? new ConfigData(data) : new ConfigData(data, ttl);
+    }
+
+    /**
+     * Retrieves the raw secret string without JSON key extraction.
+     * Used when the key selector is '*' (e.g., ${secretsmanager:mySecret:*}).
+     * Returns the entire secret value as-is, allowing the consumer to parse it directly.
+     */
+    private ConfigData getRawSecret(String path) {
+        Map<String, String> data = new HashMap<>();
+        GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
+        try {
+            SecretsManagerClient secretsClient = checkOrInitSecretManagerClient();
+            GetSecretValueResponse response = secretsClient.getSecretValue(request);
+            data.put(RAW_SECRET_KEY, response.secretString());
+        } catch (ResourceNotFoundException e) {
+            log.info("Secret id {} not found. Value will be handled according to a strategy defined by 'NotFoundStrategy'", path);
+            handleNotFoundByStrategy(data, path, null, e);
+        }
+        return new ConfigData(data);
     }
 
     protected synchronized SecretsManagerClient checkOrInitSecretManagerClient() {

--- a/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
+++ b/src/main/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProvider.java
@@ -19,6 +19,7 @@ package com.amazonaws.kafka.config.providers;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -58,10 +59,14 @@ import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundExce
  * #        Step 2. Usage of AWS secrets manager as config provider:
  * db.username=${secretsmanager:AmazonMSK_TestKafkaConfig:username}
  * db.password=${secretsmanager:AmazonMSK_TestKafkaConfig:password}
+ *
+ * #        Alternatively, omit the key to retrieve the entire secret value as a raw string:
+ * db.config=${secretsmanager:AmazonMSK_TestKafkaConfig}
  * </pre>
  *
- * Note, this config provider implementation assumes secret values will be returned in Json format.
- * Nested values aren't supported at this point.<br>
+ * Note, the three-segment form assumes secret values will be returned in Json format.
+ * Nested values aren't supported at this point. The two-segment form (no key) returns the
+ * raw secret string without any JSON parsing, allowing the consumer to handle the structure directly.<br>
  *
  * SecretsManagerConfigProvider can be configured using parameters.<br>
  * Format:<br>
@@ -84,10 +89,10 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String EMPTY = "";
-    private static final String RAW_SECRET_KEY = "*";
 
     private SecretsManagerConfig config;
     private String notFoundStrategy;
+    private String rawSecretEncoding;
 
     private SecretsManagerClient secretsManager;
 
@@ -101,6 +106,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         setCommonConfig(config);
 
         this.notFoundStrategy = config.getString(SecretsManagerConfig.NOT_FOUND_STRATEGY);
+        this.rawSecretEncoding = config.getString(SecretsManagerConfig.RAW_SECRET_ENCODING);
 
         // set up a builder:
         SecretsManagerClientBuilder cBuilder = SecretsManagerClient.builder();
@@ -130,19 +136,21 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
     @Override
     public ConfigData get(String encodedPath, Set<String> keys) {
         Map<String, String> data = new HashMap<>();
-        if (encodedPath == null || encodedPath.isEmpty()
-            || keys== null || keys.isEmpty()) {
+        if (encodedPath == null || keys == null || keys.isEmpty()) {
             // if no fields provided, just ignore this usage
             return new ConfigData(data);
         }
 
         String path = URLDecoder.decode(encodedPath, StandardCharsets.UTF_8);
 
-        if (keys.size() == 1 && parseKey(keys.iterator().next()).equals(RAW_SECRET_KEY)) {
+        if (path.isEmpty()) {
+            // Two-segment form: ${secretsmanager:secretName} — path is absent, key holds the secret identifier.
+            // Returns the entire secret value as-is for the consumer to parse directly.
             String keyWithOptions = keys.iterator().next();
+            String secretId = URLDecoder.decode(parseKey(keyWithOptions), StandardCharsets.UTF_8);
             Map<String, String> options = parseKeyOptions(keyWithOptions);
             Long ttl = getUpdatedTtl(null, options);
-            return getRawSecret(path, keyWithOptions, ttl);
+            return getRawSecret(secretId, keyWithOptions, ttl);
         }
 
         GetSecretValueRequest request = GetSecretValueRequest.builder().secretId(path).build();
@@ -187,7 +195,7 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
 
     /**
      * Retrieves the raw secret string without JSON key extraction.
-     * Used when the key selector is '*' (e.g., ${secretsmanager:mySecret:*}).
+     * Used when the two-segment form is specified (e.g., ${secretsmanager:mySecret}).
      * Returns the entire secret value as-is, allowing the consumer to parse it directly.
      */
     private ConfigData getRawSecret(String path, String keyWithOptions, Long ttl) {
@@ -196,7 +204,11 @@ public class SecretsManagerConfigProvider extends AwsServiceConfigProvider {
         try {
             SecretsManagerClient secretsClient = checkOrInitSecretManagerClient();
             GetSecretValueResponse response = secretsClient.getSecretValue(request);
-            data.put(keyWithOptions, response.secretString());
+            String secretValue = response.secretString();
+            if (SecretsManagerConfig.RAW_SECRET_ENCODING_BASE64.equals(rawSecretEncoding)) {
+                secretValue = Base64.getEncoder().encodeToString(secretValue.getBytes(StandardCharsets.UTF_8));
+            }
+            data.put(keyWithOptions, secretValue);
         } catch (ResourceNotFoundException e) {
             log.info("Secret id {} not found. Value will be handled according to a strategy defined by 'NotFoundStrategy'", path);
             handleNotFoundByStrategy(data, path, null, e);

--- a/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/MockedSecretsManagerConfigProvider.java
@@ -26,6 +26,9 @@ public class MockedSecretsManagerConfigProvider extends SecretsManagerConfigProv
         when(secretsClient.getSecretValue(request("AmazonMSK_TestTTL"))).thenAnswer(
                 (Answer<GetSecretValueResponse>) invocation -> response("{\"username\": \"John\", \"password\":\"Password123\"}")
         );
+        when(secretsClient.getSecretValue(request("AmazonMSK_NestedConfig"))).thenAnswer(
+                (Answer<GetSecretValueResponse>) invocation -> response("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}")
+        );
         when(secretsClient.getSecretValue(request("notFound"))).thenThrow(ResourceNotFoundException.class);
         return secretsClient;
     }

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -118,8 +118,8 @@ public class SecretsManagerConfigProviderTest {
     }
 
     @Test
-    public void testRawSecretWildcardKey() {
-        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig:*}");
+    public void testRawSecretTwoSegmentForm() {
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig}");
 
         RawSecretConfig testConfig = new RawSecretConfig(props);
 
@@ -128,18 +128,53 @@ public class SecretsManagerConfigProviderTest {
     }
 
     @Test
-    public void testRawSecretWithTtl() {
-        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig:*?ttl=60000}");
+    public void testRawSecretTwoSegmentFormWithTtl() {
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig?ttl=60000}");
 
         RawSecretConfig testConfig = new RawSecretConfig(props);
 
         String rawJson = testConfig.getString("connectionConfig");
         assertEquals("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}", rawJson);
+    }
+
+    @Test
+    public void testRawSecretTwoSegmentFormViaArn() {
+        String arn = URLEncoder.encode("arn:aws:secretsmanager:ap-southeast-2:123456789:secret:AmazonMSK_my_service/my_secret", StandardCharsets.UTF_8);
+        props.put("connectionConfig", "${secretsmanager:" + arn + "}");
+
+        RawSecretConfig testConfig = new RawSecretConfig(props);
+
+        String rawJson = testConfig.getString("connectionConfig");
+        assertEquals("{\"username\": \"John2\", \"password\":\"Password567\"}", rawJson);
+    }
+
+    @Test
+    public void testRawSecretTwoSegmentFormBase64Encoded() {
+        props.put("config.providers.secretsmanager.param.RawSecretEncoding", "base64");
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig}");
+
+        RawSecretConfig testConfig = new RawSecretConfig(props);
+
+        String encoded = testConfig.getString("connectionConfig");
+        String decoded = new String(java.util.Base64.getDecoder().decode(encoded), java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}", decoded);
+    }
+
+    @Test
+    public void testRawSecretTwoSegmentFormBase64EncodedWithTtl() {
+        props.put("config.providers.secretsmanager.param.RawSecretEncoding", "base64");
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig?ttl=60000}");
+
+        RawSecretConfig testConfig = new RawSecretConfig(props);
+
+        String encoded = testConfig.getString("connectionConfig");
+        String decoded = new String(java.util.Base64.getDecoder().decode(encoded), java.nio.charset.StandardCharsets.UTF_8);
+        assertEquals("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}", decoded);
     }
 
     @Test
     public void testRawSecretNotFound() {
-        props.put("connectionConfig", "${secretsmanager:notFound:*}");
+        props.put("connectionConfig", "${secretsmanager:notFound}");
         assertThrows(ResourceNotFoundException.class, () -> new RawSecretConfig(props));
     }
 

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -128,6 +128,16 @@ public class SecretsManagerConfigProviderTest {
     }
 
     @Test
+    public void testRawSecretWithTtl() {
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig:*?ttl=60000}");
+
+        RawSecretConfig testConfig = new RawSecretConfig(props);
+
+        String rawJson = testConfig.getString("connectionConfig");
+        assertEquals("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}", rawJson);
+    }
+
+    @Test
     public void testRawSecretNotFound() {
         props.put("connectionConfig", "${secretsmanager:notFound:*}");
         assertThrows(ResourceNotFoundException.class, () -> new RawSecretConfig(props));

--- a/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
+++ b/src/test/java/com/amazonaws/kafka/config/providers/SecretsManagerConfigProviderTest.java
@@ -116,7 +116,23 @@ public class SecretsManagerConfigProviderTest {
         props.put("notFound", "${secretsmanager:AmazonMSK_TestKafkaConfig:noKey}");
         assertThrows(ConfigException.class, () ->new CustomConfig(props));
     }
-    
+
+    @Test
+    public void testRawSecretWildcardKey() {
+        props.put("connectionConfig", "${secretsmanager:AmazonMSK_NestedConfig:*}");
+
+        RawSecretConfig testConfig = new RawSecretConfig(props);
+
+        String rawJson = testConfig.getString("connectionConfig");
+        assertEquals("{\"host\": \"broker-1:9092\", \"credentials\": {\"username\": \"admin\", \"password\": \"secret\"}, \"options\": {\"timeout\": \"30\", \"retries\": \"3\"}}", rawJson);
+    }
+
+    @Test
+    public void testRawSecretNotFound() {
+        props.put("connectionConfig", "${secretsmanager:notFound:*}");
+        assertThrows(ResourceNotFoundException.class, () -> new RawSecretConfig(props));
+    }
+
     static class CustomConfig extends AbstractConfig {
         final static String DEFAULT_DOC = "Default Doc";
         final static ConfigDef CONFIG = new ConfigDef()
@@ -124,6 +140,16 @@ public class SecretsManagerConfigProviderTest {
                 .define("password", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
                 ;
         public CustomConfig(Map<?, ?> originals) {
+            super(CONFIG, originals);
+        }
+    }
+
+    static class RawSecretConfig extends AbstractConfig {
+        final static String DEFAULT_DOC = "Default Doc";
+        final static ConfigDef CONFIG = new ConfigDef()
+                .define("connectionConfig", Type.STRING, "defaultValue", Importance.HIGH, DEFAULT_DOC)
+                ;
+        public RawSecretConfig(Map<?, ?> originals) {
             super(CONFIG, originals);
         }
     }


### PR DESCRIPTION
When the key selector is '\*' (e.g., ${secretsmanager:mySecret:*}), return the entire secret value as a raw string without JSON key extraction. This enables consumers to parse secrets containing nested JSON structures that cannot be represented as flat key-value maps.

*Issue #, if available:* N/A

*Description of changes:* Adds support for fetching the entire secret as is. This allows for consumers to fetch secrets that are not flat key/value pairs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
